### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/minisyntax.php
+++ b/syntax/minisyntax.php
@@ -29,7 +29,7 @@ class syntax_plugin_minimap_minisyntax extends DokuWiki_Syntax_Plugin
     // The handle function goal is to parse the matched syntax through the pattern function
     // and to return the result for use in the renderer
     // This result is always cached until the page is modified.
-    function handle($match, $state, $pos, &$handler)
+    function handle($match, $state, $pos, Doku_Handler $handler)
     {
 
         switch ($state) {
@@ -59,7 +59,7 @@ class syntax_plugin_minimap_minisyntax extends DokuWiki_Syntax_Plugin
     }
 
 
-    function render($mode, &$renderer, $data)
+    function render($mode, Doku_Renderer $renderer, $data)
     {
 
         // The $data variable comes from the handle() function


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
